### PR TITLE
fix: update bioconda-stats subrepo from branch

### DIFF
--- a/.github/workflows/generate-plots.yml
+++ b/.github/workflows/generate-plots.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Update submodule
       run: |
-        git pull --recurse-submodules
+        git pull --no-recurse-submodules
         git submodule update --remote --recursive
 
     - name: Generate plots

--- a/.github/workflows/generate-plots.yml
+++ b/.github/workflows/generate-plots.yml
@@ -24,7 +24,8 @@ jobs:
     - name: Update submodule
       run: |
         git pull --no-recurse-submodules
-        git submodule update
+        git submodule foreach git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+        git submodule update --remote --recursive
 
     - name: Generate plots
       run: |

--- a/.github/workflows/generate-plots.yml
+++ b/.github/workflows/generate-plots.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Update submodule
       run: |
         git pull --no-recurse-submodules
-        git submodule update --remote --recursive
+        git submodule update
 
     - name: Generate plots
       run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "bioconda-stats"]
 	path = bioconda-stats
 	url = https://github.com/bioconda/bioconda-stats
+	branch = data


### PR DESCRIPTION

First error:
>fatal: remote error: upload-pack: not our ref 005e94d56ed39c446b0424d8d5cfccdb796ac2c1

What I think was happening is that the pull was somehow referencing an old submodule commit because I can not figure out where the `005e94d56ed39c446b0424d8d5cfccdb796ac2c1` hash that it was failing is coming from. `git pull --no-recurse-submodules` avoids that issue.


After that, got a different error:
>fatal: Unable to find refs/remotes/origin/data revision in submodule path 'bioconda-stats'

For some reason the submodule's fetch was set to only pull from the main branch, even though `.gitmodules` has the branch name. `git submodule foreach git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'` allows it to pull the data branch and do the submodule update from the branch.


Assuming this resolves checkout issues after merging, I am planning on disabling the workflow since the other changes could take some time.