### PR TITLE
Use tsv from bioconda-stats to build plot json

### DIFF
--- a/.github/workflows/generate-plots.yml
+++ b/.github/workflows/generate-plots.yml
@@ -24,7 +24,8 @@ jobs:
     - name: Update submodule
       run: |
         git pull --no-recurse-submodules
-        git submodule foreach git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+        git submodule foreach git fetch --tags
+        git submodule foreach git config remote.origin.fetch '+refs/heads/data:refs/remotes/origin/data'
         git submodule update --remote --recursive
 
     - name: Generate plots

--- a/.github/workflows/generate-plots.yml
+++ b/.github/workflows/generate-plots.yml
@@ -29,6 +29,7 @@ jobs:
 
     - name: Generate plots
       run: |
+        pip install GitPython pandas
         python src/plot_cdf.py
         python src/plot_versions.py
 

--- a/.github/workflows/test-plots.yml
+++ b/.github/workflows/test-plots.yml
@@ -21,5 +21,6 @@ jobs:
 
     - name: Generate plots
       run: |
+        pip install GitPython pandas
         python src/plot_cdf.py
         python src/plot_versions.py

--- a/.github/workflows/test-plots.yml
+++ b/.github/workflows/test-plots.yml
@@ -19,6 +19,10 @@ jobs:
       with:
         python-version: 3.9
 
+    - name: Fetch submodule tags
+      run: |
+        git submodule foreach git fetch --tags
+
     - name: Generate plots
       run: |
         pip install GitPython pandas

--- a/.github/workflows/test-plots.yml
+++ b/.github/workflows/test-plots.yml
@@ -23,4 +23,4 @@ jobs:
       run: |
         pip install GitPython pandas
         python src/plot_cdf.py
-        python src/plot_versions.py
+        python src/plot_versions.py 5 100

--- a/src/plot_cdf.py
+++ b/src/plot_cdf.py
@@ -1,16 +1,12 @@
-from collections import defaultdict
 import json
 import os
 import pandas as pd
-
-def read_tsv(path):
-    return pd.read_csv(path, sep="\t", dtype=defaultdict(lambda: str, total=int))
 
 plot_data = []
 packages = []
 
 # Get most recent number of downloads for each package
-df = read_tsv("bioconda-stats/package-downloads/anaconda.org/bioconda/packages.tsv")
+df = pd.read_csv("bioconda-stats/package-downloads/anaconda.org/bioconda/packages.tsv", sep="\t")
 downloads = df.sort_values(by=['total'])
 downloads = downloads.set_index("package")
 downloads = downloads.to_dict('dict')
@@ -18,7 +14,6 @@ downloads = downloads.to_dict('dict')
 # init array with number of items equal to highest number of downloads of any given package divided by 100
 max_downloads = df["total"].max()
 data = [0] * int((max_downloads/100))
-
 
 # For each of these buckets, count and collect the packages with downloads <= to the bucket range (1/100th of the max downloads)
 for i in range(int(max_downloads/100)):

--- a/src/plot_cdf.py
+++ b/src/plot_cdf.py
@@ -1,34 +1,43 @@
-import copy
-import os
+from collections import defaultdict
 import json
+import os
+import pandas as pd
 
-downloads = {}
+def read_tsv(path):
+    return pd.read_csv(path, sep="\t", dtype=defaultdict(lambda: str, total=int))
+
 plot_data = []
 packages = []
 
-for filename in os.listdir('bioconda-stats/package-downloads/anaconda.org/bioconda/'):
-    if filename.endswith(".json"):
-        with open(f"bioconda-stats/package-downloads/anaconda.org/bioconda/{filename}", "r") as file:
-            data = json.load(file)
-            downloads[filename[:-5]] = data["downloads_per_date"].pop()["total"]
+# Get most recent number of downloads for each package
+df = read_tsv("bioconda-stats/package-downloads/anaconda.org/bioconda/packages.tsv")
+downloads = df.sort_values(by=['total'])
+downloads = downloads.set_index("package")
+downloads = downloads.to_dict('dict')
 
-max_downloads = max(downloads.values())
+# init array with number of items equal to highest number of downloads of any given package divided by 100
+max_downloads = df["total"].max()
 data = [0] * int((max_downloads/100))
 
+
+# For each of these buckets, count and collect the packages with downloads <= to the bucket range (1/100th of the max downloads)
 for i in range(int(max_downloads/100)):
     if i == 0:
         count = 0
     else:
         count = data[i - 1]
-    for package, download_count in sorted(downloads.items(), key=lambda item: item[1]):
+    package_list = list(downloads["total"].items())
+    for package, download_count in package_list:
         if download_count <= i*100:
             count += 1
             packages.append({"package": package, "downloads": i*100, "count": count})
-            del downloads[package]
+            del downloads["total"][package]
         else:
             data[i] = count
             break
 
+
+# The overall plot has the number of packages in each download count bucket
 for (i, d) in enumerate(data[1:], 1):
     plot_data.append({"pos": i*100, "count": d})
 
@@ -38,6 +47,7 @@ if not os.path.exists("plots"):
 with open(f"plots/cdf.json", "w") as cdf:
     cdf.writelines(json.dumps(plot_data))
 
+# The per item cdf.json contains the x,y point for this particular package.
 for p in packages:
     package = p["package"]
     if not os.path.exists(f"plots/{package}"):

--- a/src/plot_versions.py
+++ b/src/plot_versions.py
@@ -98,6 +98,6 @@ for filename in os.listdir(
                 break
 
 if error_count > 0:
-    raise RuntimeError(f"Errors occurred for {error_count} out of {max_packages} packages.")
+    raise RuntimeError(f"Errors occurred for {error_count} out of {package_count} packages.")
 else:
-    logger.info(f"Completed {max_packages} packages.")
+    logger.info(f"Completed {package_count} packages.")

--- a/src/plot_versions.py
+++ b/src/plot_versions.py
@@ -2,6 +2,11 @@ import io
 import os
 import pandas as pd
 from git import Repo
+from logging import DEBUG, basicConfig, getLogger
+
+
+basicConfig(level=DEBUG)
+logger = getLogger(__name__)
 
 if not os.path.exists("plots"):
     os.makedirs("plots")
@@ -15,52 +20,62 @@ for filename in os.listdir(
 ):
     if filename.endswith(".tsv"):
         package = filename[:-4]
+        try:
+            logger.info(f"Loading data for package: {package}")
+            package_df = pd.DataFrame()
+            tagref = None
 
-        if not os.path.exists(f"plots/{package}"):
-            os.makedirs(f"plots/{package}")
+            df = pd.read_csv(f"bioconda-stats/package-downloads/anaconda.org/bioconda/versions/{filename}", encoding="utf-8", sep="\t")
+            versions = set(df["version"])
+            prev_tagname = tags[len(tags) - 1].name
 
-        versions = set()
-        package_df = pd.DataFrame()
-        df = None
-        tagref = None
-        prev_tag = None
-        # Get tags going back 15 days
-        for days_back in range(0, 15):
-            if tagref is not None:
-                prev_tag = tagref
-            tagref = repo.tags[len(repo.tags) - 1 - days_back]
-            subtree = (
-                tagref.commit.tree / "package-downloads/anaconda.org/bioconda/versions"
-            )
+            # Get tags going back 15 days
+            for days_back in range(1, 15):
+                if tagref is not None:
+                    prev_tagname = tagref.name
+                tagref = tags[len(tags) - 1 - days_back]
+                subtree = (
+                    tagref.commit.tree / "package-downloads/anaconda.org/bioconda/versions"
+                )
 
-            # Get a previous tagged version of the package stats tsv
-            try:
-                blob = subtree / filename
-            except KeyError:
-                # does not exist
-                continue
+                # Get a previous tagged version of the package stats tsv
+                try:
+                    blob = subtree / filename
+                except KeyError:
+                    # does not exist
+                    break
 
-            new_df = pd.read_csv(
-                io.BytesIO(blob.data_stream.read()), encoding="utf-8", sep="\t"
-            )
-            # do a delta between totals of different dates
-            versions = versions | set(new_df["version"])
-            if df is not None:
+                logger.debug(f"Found data for {package} from date {tagref.name}.")
+                new_df = pd.read_csv(
+                    io.BytesIO(blob.data_stream.read()), encoding="utf-8", sep="\t"
+                )
+                # do a delta between totals of different dates
+                versions = versions | set(new_df["version"])
                 df_sub = df.set_index("version").subtract(new_df.set_index("version"), fill_value=0)
                 df_sub.rename(columns={"total": "delta"}, inplace=True)
                 df = df.merge(df_sub, on="version")
-                df["date"] = prev_tag.name
+                df["date"] = prev_tagname
                 package_df = pd.concat([package_df, df], ignore_index=True)
-            df = new_df
+                df = new_df
 
-        # Sort by version (for semantic versioning)
-        versions = list(versions)
-        if all([all(list(map(lambda x: x.isdigit(), str(v).split('.')))) for v in versions]):
-            versions.sort(key=lambda s: list(map(int, str(s).split('.'))))
-        
-        package_df['version'] = pd.Categorical(package_df['version'], ordered=True, categories=versions)
-        package_df = package_df.sort_values(by=['version','date'])[["date", "total", "delta", "version"]]
+            if len(package_df.index) > 0:
+                # Sort by version (for semantic versioning)
+                versions = list(versions)
+                if all([all(list(map(lambda x: x.isdigit(), str(v).split(".")))) for v in versions]):
+                    versions.sort(key=lambda s: list(map(int, str(s).split("."))))
+                
+                package_df["version"] = pd.Categorical(package_df["version"], ordered=True, categories=versions)
+                package_df = package_df.sort_values(by=["version","date"])[["date", "total", "delta", "version"]]
 
-        # Save plot data
-        with open(f"plots/{package}/versions.json", "w") as v:
-            v.writelines(package_df.to_json(orient='records'))
+                # Save plot data
+                if not os.path.exists(f"plots/{package}"):
+                    os.makedirs(f"plots/{package}")
+                with open(f"plots/{package}/versions.json", "w") as v:
+                    v.writelines(package_df.to_json(orient="records"))
+                    logger.debug(f"Saved data for {package} to versions.json.")
+
+        except Exception as e:
+            # Log package name and continue with the rest
+            e.args = (f"Error creating plot for {package}.",) + e.args
+            logger.exception(e)
+

--- a/src/plot_versions.py
+++ b/src/plot_versions.py
@@ -1,35 +1,66 @@
-import json
+import io
 import os
+import pandas as pd
+from git import Repo
 
 if not os.path.exists("plots"):
     os.makedirs("plots")
 
-for filename in os.listdir('bioconda-stats/package-downloads/anaconda.org/bioconda/'):
-    if filename.endswith(".json"):
-        package = filename[:-5]
+repo = Repo("bioconda-stats")
+tags = repo.tags
+
+# for each package, get the most recent versions.tsv
+for filename in os.listdir(
+    "bioconda-stats/package-downloads/anaconda.org/bioconda/versions"
+):
+    if filename.endswith(".tsv"):
+        package = filename[:-4]
 
         if not os.path.exists(f"plots/{package}"):
             os.makedirs(f"plots/{package}")
 
-        versions = []
-        values = []
-        for version_filename in os.listdir(f'bioconda-stats/package-downloads/anaconda.org/bioconda/{package}'):
-            if version_filename.endswith(".json"):
-                versions.append(version_filename[:-5])
+        versions = set()
+        package_df = pd.DataFrame()
+        df = None
+        tagref = None
+        prev_tag = None
+        # Get tags going back 15 days
+        for days_back in range(0, 15):
+            if tagref is not None:
+                prev_tag = tagref
+            tagref = repo.tags[len(repo.tags) - 1 - days_back]
+            subtree = (
+                tagref.commit.tree / "package-downloads/anaconda.org/bioconda/versions"
+            )
 
-        if all([all(list(map(lambda x: x.isdigit(), v.split('.')))) for v in versions]):
-            versions.sort(key=lambda s: list(map(int, s.split('.'))))
+            # Get a previous tagged version of the package stats tsv
+            try:
+                blob = subtree / filename
+            except KeyError:
+                # does not exist
+                continue
 
-        for version in versions[-7:]:
-            with open(f"bioconda-stats/package-downloads/anaconda.org/bioconda/{package}/{version}.json", "r") as file:
-                data = json.load(file)
-                data = data["downloads_per_date"]
-                days = min(len(data), 15)
-                data = data[-days:]
-                for i, entry in enumerate(data[-(days - 1):], 1):
-                    entry["delta"] = entry["total"] - data[i - 1]["total"]
-                    entry["version"] = version
-                values.extend(data[-(days - 1):])
+            new_df = pd.read_csv(
+                io.BytesIO(blob.data_stream.read()), encoding="utf-8", sep="\t"
+            )
+            # do a delta between totals of different dates
+            versions = versions | set(new_df["version"])
+            if df is not None:
+                df_sub = df.set_index("version").subtract(new_df.set_index("version"), fill_value=0)
+                df_sub.rename(columns={"total": "delta"}, inplace=True)
+                df = df.merge(df_sub, on="version")
+                df["date"] = prev_tag.name
+                package_df = pd.concat([package_df, df], ignore_index=True)
+            df = new_df
 
-            with open(f"plots/{package}/versions.json", "w") as v:
-                v.writelines(json.dumps(values))
+        # Sort by version (for semantic versioning)
+        versions = list(versions)
+        if all([all(list(map(lambda x: x.isdigit(), str(v).split('.')))) for v in versions]):
+            versions.sort(key=lambda s: list(map(int, str(s).split('.'))))
+        
+        package_df['version'] = pd.Categorical(package_df['version'], ordered=True, categories=versions)
+        package_df = package_df.sort_values(by=['version','date'])[["date", "total", "delta", "version"]]
+
+        # Save plot data
+        with open(f"plots/{package}/versions.json", "w") as v:
+            v.writelines(package_df.to_json(orient='records'))

--- a/src/plot_versions.py
+++ b/src/plot_versions.py
@@ -2,10 +2,10 @@ import io
 import os
 import pandas as pd
 from git import Repo
-from logging import DEBUG, basicConfig, getLogger
+from logging import INFO, basicConfig, getLogger
 
 
-basicConfig(level=DEBUG)
+basicConfig(level=INFO)
 logger = getLogger(__name__)
 
 if not os.path.exists("plots"):
@@ -21,7 +21,7 @@ for filename in os.listdir(
     if filename.endswith(".tsv"):
         package = filename[:-4]
         try:
-            logger.info(f"Loading data for package: {package}")
+            logger.debug(f"Loading data for package: {package}")
             package_df = pd.DataFrame()
             tagref = None
 


### PR DESCRIPTION
Since the stats for each package are now tagged by date, use GitPython to get the package .tsv file for the past 15 tags.

The CDF plot doesn't require past data, so that was just a matter of updating to tsv.

There are definitely some more improvements to be made, but the first goal was just to get these plots building again.

Future work:
- Improve performance of package version download plots (It currently takes 2 hours to build all the plots. This may be due to getting the file content from git history.)
- CDF could be improved by taking advantage of pandas functionality.